### PR TITLE
[Fix] EventListener의 트랜잭션 범위 변경

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   detect-changes:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - main
+      - develop
 
 jobs:
   detect-changes:

--- a/spring/src/main/java/com/a508/onestep/domain/signal/listener/UserSignalLogEventListener.java
+++ b/spring/src/main/java/com/a508/onestep/domain/signal/listener/UserSignalLogEventListener.java
@@ -1,6 +1,5 @@
 package com.a508.onestep.domain.signal.listener;
 
-import com.a508.onestep.domain.challenge.event.ChallengeCompletedEvent;
 import com.a508.onestep.domain.signal.entity.UserSignalLog;
 import com.a508.onestep.domain.signal.event.UserSignalLogEvent;
 import com.a508.onestep.domain.signal.repository.UserSignalLogRepository;
@@ -8,11 +7,11 @@ import com.a508.onestep.global.logging.utils.LogUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
@@ -28,9 +27,9 @@ public class UserSignalLogEventListener {
     private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
     @Async("taskExecutor")
-    @EventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleChallengeCompletedEvent(UserSignalLogEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    public void handleUserSignalLogEvent(UserSignalLogEvent event) {
         LogUtils.info("UserSignalLog 저장 : userCode = {}, targetId = {}, eventType = {}",
                 event.getUserCode(), event.getTargetId(), event.getEventType()
         );

--- a/spring/src/main/resources/application-dev.yaml
+++ b/spring/src/main/resources/application-dev.yaml
@@ -9,6 +9,14 @@ spring:
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
 
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 3000
+      idle-timeout: 300000
+      max-lifetime: 580000
+      leak-detection-threshold: 10000
+
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## relavant issue number
- #4 

## 어떤 이유로 MR를 하셨나요?
- [ ] feature 병합(feature issue #를 남겨주세요)
- [x] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용

1000명 접속 부하테스트 중 다음 오류 발생
```
HikariPool-1 - Connection is not available, request timed out after 30002ms (total=10, active=10, idle=0, waiting=23)
```

<img width="30%" alt="image" src="https://github.com/user-attachments/assets/e3ea1829-1a58-4248-a3de-2ea00b6ac965" />

`/api/v1/challenges/complete` 엔드포인트에서 타임아웃 에러 123건 확인

<br>

### 원인 분석

- 챌린지 완료 처리 흐름에서 커넥션 풀 고갈 발생
    - 챌린지 완료-> 트랜잭션 시작(커넥션 1개 점유)
    - 이벤트 리스너가 동기적으로 보상 관련 로직에 대해 실행
    - 그 후에 `UserSignalLogEvent`가 실행 -> `Propagation.REQUIRES_NEW`로 인해서 **기존 트랜잭션이 커넥션을 점유한 상태에서 새 커넥션을 요청**
    - HikariCP max pool size가 10인 상황에서 동시 요청이 몰리면 새 커넥션을 확보하지 못해 타임아웃 발생

또한 `Async`의 `CallerRunsPolicy` 설정으로 인해 스레드 풀이 가득 차면 요청 스레드에서 직접 실행되어 장애가 증폭되는 구조였습니다.

<br>

- **이전 코드**
```java
@Async("taskExecutor")
@EventListener
@Transactional(propagation = Propagation.REQUIRES_NEW)
public void handleChallengeCompletedEvent(UserSignalLogEvent event) {
```
- EventListener는 발행시점에서 실행되니까 발행이 트랜잭션 내부에서 일어나면 리스너도 거기서 일어날 수 있고, 지금 REQUIRES_NEW가 새 커넥션을 즉시 요구하면서 터짐
- 기존 커넥션이 해제되기 전에 새 커넥션을 요청하는 데드락 유사 구조

<br>

- **이후 코드**
```java
    @Async("taskExecutor")
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
    @Transactional
    public void handleUserSignalLogEvent(UserSignalLogEvent event) {
```
- `TransactionalEventListener(AFTER_COMMIT)`으로 발행 트랜잭션이 커밋된 후 이벤트를 실행하여 -> 기존 커넥션이 반환된 상태에서 새 트랜잭션 시작
- `Transactional` AOP 추가해서 별도 트랜잭션에서 안정적으로 커넥션을 확보하게 추가
- `REQUIRES_NEW` 제거로 불필요한 중첩 트랜잭션 방지