### PR TITLE
[Hotfix] Transactional REQUIRES_NEW 추가

### DIFF
--- a/docker/local/k6/script.js
+++ b/docker/local/k6/script.js
@@ -6,7 +6,7 @@ export const options = {
     insecureSkipTLSVerify: true, // SSL 인증서 무시 (Ignore SSL certificate errors)
 
     stages: [
-        { duration: '10m', target: 500 },
+        { duration: '10m', target: 1000 },
     ],
 };
 

--- a/spring/src/main/java/com/a508/onestep/domain/signal/listener/UserSignalLogEventListener.java
+++ b/spring/src/main/java/com/a508/onestep/domain/signal/listener/UserSignalLogEventListener.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -28,7 +29,7 @@ public class UserSignalLogEventListener {
 
     @Async("taskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleUserSignalLogEvent(UserSignalLogEvent event) {
         LogUtils.info("UserSignalLog 저장 : userCode = {}, targetId = {}, eventType = {}",
                 event.getUserCode(), event.getTargetId(), event.getEventType()

--- a/spring/src/main/resources/application-local.yaml
+++ b/spring/src/main/resources/application-local.yaml
@@ -28,11 +28,11 @@ spring:
       password: ${LOCAL_REDIS_PASSWORD}
 
     mongodb:
-      host: ${MONGO_HOST}
-      port: ${MONGO_PORT}
-      database: ${MONGO_DB_NAME}
-      username: ${MONGO_USERNAME}
-      password: ${MONGO_PASSWORD}
+      host: ${LOCAL_MONGO_HOST}
+      port: ${LOCAL_MONGO_PORT}
+      database: ${LOCAL_MONGO_DB_NAME}
+      username: ${LOCAL_MONGO_USERNAME}
+      password: ${LOCAL_MONGO_PASSWORD}
       authentication-database: admin
 
   kafka:


### PR DESCRIPTION
## 어떤 이유로 MR를 하셨나요?
- [ ] feature 병합(feature issue #를 남겨주세요)
- [x] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용

- `Transactional`의 기본 전파 옵션은 REQUIRED
- 트랜잭션 이벤트 리스너와 함께 쓰면 트랜잭션 경계가 애매해질 수 있어서 스프링 차원에서 막음
- (`TransactionalEventListener`는 트랜잭션의 특정 시점(커밋 후/롤백 후 등)에 이벤트를 실행시키기 위한 용도인데
여기에 `Transactional(REQUIRED)`를 함께 붙이면 “기존 트랜잭션에 참여하는 건지 / 새로 여는 건지”가 모호 -> 잘못된 사용으로 이어질 가능성이 있기 때문)
- **"그래서 Spring Framework 6.2부터는 TransactionalEventListener 메서드에 Transactional을 같이 쓰는 걸 기본적으로 제한하고,
허용되지 않는 조합이면 애플리케이션 시작 단계에서 예외를 터뜨려 부팅을 막음(RestrictedTransactionalEventListenerFactory)."**

<br><br>

- Transactional의 propagation을 명시적으로 REQUIRES_NEW로 지정
- 이벤트는 원래 트랜잭션 커밋 이후(AFTER_COMMIT)에 실행되고, 그 이벤트 처리 로직은 별도의 새 트랜잭션으로 동작하게 되어 의도가 명확히 지정
- TransactionalEventListener(phase = AFTER_COMMIT): 원 트랜잭션이 커밋된 뒤 이벤트 처리 실행
- Transactional(propagation = REQUIRES_NEW): 이벤트 처리 시 무조건 새 트랜잭션을 열어서 작업
- Async("taskExecutor"): 이벤트 처리를 비동기로 분리해서 본 트랜잭션 흐름과 실행 스레드를 분리