### PR TITLE
[Feat] 트레이스 로깅 추가하기

### DIFF
--- a/docker/dev/docker-compose.monitoring.yaml
+++ b/docker/dev/docker-compose.monitoring.yaml
@@ -83,34 +83,18 @@ services:
     networks:
       - monitoring
 
-  pmm-server:
-    image: percona/pmm-server:2
-    container_name: pmm-server
-    restart: unless-stopped
+  tempo:
+    image: grafana/tempo:2.6.1
+    container_name: tempo
+    env_file:
+      - .env
+    command: [ "-config.file=/etc/tempo/tempo.yml", "-config.expand-env=true" ]
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yml:ro
+      - tempo-data:/var/tempo
     ports:
-      - "4443:443"
-      - "8090:80"
-    volumes:
-      - pmm-data:/srv
-    networks:
-      - monitoring
-
-  pmm-client:
-    image: percona/pmm-client:2
-    container_name: pmm-client
-    restart: unless-stopped
-    depends_on:
-      - pmm-server
-    environment:
-      PMM_AGENT_SERVER_ADDRESS: pmm-server:443
-      PMM_AGENT_SERVER_USERNAME: admin
-      PMM_AGENT_SERVER_PASSWORD: admin
-      PMM_AGENT_SERVER_INSECURE_TLS: "1"
-      PMM_AGENT_SETUP: "1"
-      PMM_AGENT_SETUP_FORCE: "1"
-      PMM_AGENT_CONFIG_FILE: pmm-agent.yaml
-    volumes:
-      - pmm-client-data:/usr/local/percona/pmm2
+      - "3200:3200"
+      - "4318:4318"
     networks:
       - monitoring
 

--- a/docker/dev/docker-compose.pmm.yaml
+++ b/docker/dev/docker-compose.pmm.yaml
@@ -1,0 +1,38 @@
+services:
+  pmm-server:
+    image: percona/pmm-server:2
+    container_name: pmm-server
+    restart: unless-stopped
+    ports:
+      - "4443:443"
+      - "8090:80"
+    volumes:
+      - pmm-data:/srv
+    networks:
+      - monitoring
+
+  pmm-client:
+    image: percona/pmm-client:2
+    container_name: pmm-client
+    restart: unless-stopped
+    depends_on:
+      - pmm-server
+    environment:
+      PMM_AGENT_SERVER_ADDRESS: pmm-server:443
+      PMM_AGENT_SERVER_USERNAME: admin
+      PMM_AGENT_SERVER_PASSWORD: admin
+      PMM_AGENT_SERVER_INSECURE_TLS: "1"
+      PMM_AGENT_SETUP: "1"
+      PMM_AGENT_SETUP_FORCE: "1"
+      PMM_AGENT_CONFIG_FILE: pmm-agent.yaml
+    volumes:
+      - pmm-client-data:/usr/local/percona/pmm2
+    networks:
+      - monitoring
+
+volumes:
+  pmm-data:
+  pmm-client-data:
+networks:
+  monitoring:
+    driver: bridge

--- a/docker/dev/grafana/provisioning/datasources.yaml
+++ b/docker/dev/grafana/provisioning/datasources.yaml
@@ -1,0 +1,41 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      # Loki 트레이스 로그 연동
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: "-1m"
+        spanEndTimeShift: "1m"
+        tags:
+          - key: service.name
+            value: service_name
+        filterByTraceID: true
+        filterBySpanID: false
+      # Prometheus
+      serviceMap:
+        datasourceUid: prometheus
+      # Node Graph
+      nodeGraph:
+        enabled: true
+      # Loki Search Trace
+      lokiSearch:
+        datasourceUid: loki

--- a/docker/dev/tempo/tempo-config.yaml
+++ b/docker/dev/tempo/tempo-config.yaml
@@ -6,8 +6,6 @@ distributor:
   receivers:
     otlp:
       protocols:
-        grpc:
-          endpoint: "0.0.0.0:4317"
         http:
           endpoint: "0.0.0.0:4318"
 

--- a/docker/dev/tempo/tempo-config.yaml
+++ b/docker/dev/tempo/tempo-config.yaml
@@ -1,0 +1,64 @@
+server:
+  http_listen_port: 3200
+
+# OTLP 수신
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+# Trace Storage
+storage:
+  trace:
+    backend: s3
+    s3:
+      endpoint: s3.ap-northeast-2.amazonaws.com
+      region: ap-northeast-2
+      bucket: onestep-bucket-a508
+      prefix: traces/dev
+      access_key: ${S3_ACCESS_KEY}
+      secret_key: ${S3_SECRET_KEY}
+      forcepathstyle: true
+    wal:
+      path: /var/tempo/wal
+    pool:
+      max_workers: 100
+      queue_depth: 10000
+
+# Metric 생성
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: dev
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+  processor:
+    # span-metrics
+    span_metrics:
+      dimensions:
+        - service.name
+        - http.method
+        - http.status_code
+        - http.route
+    # service-graphs
+    service_graphs:
+      dimensions:
+        - service.name
+
+# Loki
+overrides:
+  defaults:
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics

--- a/docker/local/docker-compose.monitoring.yaml
+++ b/docker/local/docker-compose.monitoring.yaml
@@ -121,34 +121,18 @@ services:
     networks:
       - monitoring
 
-  pmm-server:
-    image: percona/pmm-server:2
-    container_name: pmm-server
-    restart: unless-stopped
+  tempo:
+    image: grafana/tempo:2.6.1
+    container_name: tempo
+    env_file:
+      - .env
+    command: [ "-config.file=/etc/tempo/tempo.yml", "-config.expand-env=true" ]
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yml:ro
+      - tempo-data:/var/tempo
     ports:
-      - "4443:443"
-      - "8090:80"
-    volumes:
-      - pmm-data:/srv
-    networks:
-      - monitoring
-
-  pmm-client:
-    image: percona/pmm-client:2
-    container_name: pmm-client
-    restart: unless-stopped
-    depends_on:
-      - pmm-server
-    environment:
-      PMM_AGENT_SERVER_ADDRESS: pmm-server:443
-      PMM_AGENT_SERVER_USERNAME: admin
-      PMM_AGENT_SERVER_PASSWORD: admin
-      PMM_AGENT_SERVER_INSECURE_TLS: "1"
-      PMM_AGENT_SETUP: "1"
-      PMM_AGENT_SETUP_FORCE: "1"
-      PMM_AGENT_CONFIG_FILE: pmm-agent.yaml
-    volumes:
-      - pmm-client-data:/usr/local/percona/pmm2
+      - "3200:3200"
+      - "4318:4318"
     networks:
       - monitoring
 
@@ -157,8 +141,7 @@ volumes:
   grafana_data:
   loki_data:
   influxdb:
-  pmm-data:
-  pmm-client-data:
+  tempo-data:
 
 networks:
   monitoring:

--- a/docker/local/docker-compose.pmm.yaml
+++ b/docker/local/docker-compose.pmm.yaml
@@ -1,0 +1,43 @@
+services:
+  pmm-server:
+    image: percona/pmm-server:2
+    container_name: pmm-server
+    restart: unless-stopped
+    ports:
+      - "4443:443"
+      - "8090:80"
+    volumes:
+      - pmm-data:/srv
+    networks:
+      - monitoring
+
+  pmm-client:
+    image: percona/pmm-client:2
+    container_name: pmm-client
+    restart: unless-stopped
+    depends_on:
+      - pmm-server
+    environment:
+      PMM_AGENT_SERVER_ADDRESS: pmm-server:443
+      PMM_AGENT_SERVER_USERNAME: admin
+      PMM_AGENT_SERVER_PASSWORD: admin
+      PMM_AGENT_SERVER_INSECURE_TLS: "1"
+      PMM_AGENT_SETUP: "1"
+      PMM_AGENT_SETUP_FORCE: "1"
+      PMM_AGENT_CONFIG_FILE: pmm-agent.yaml
+    volumes:
+      - pmm-client-data:/usr/local/percona/pmm2
+    networks:
+      - monitoring
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:
+  influxdb:
+  pmm-data:
+  pmm-client-data:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/docker/local/grafana/provisioning/datasources/datasources.yaml
+++ b/docker/local/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,41 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      # Loki 트레이스 로그 연동
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: "-1m"
+        spanEndTimeShift: "1m"
+        tags:
+          - key: service.name
+            value: service_name
+        filterByTraceID: true
+        filterBySpanID: false
+      # Prometheus
+      serviceMap:
+        datasourceUid: prometheus
+      # Node Graph
+      nodeGraph:
+        enabled: true
+      # Loki Search Trace
+      lokiSearch:
+        datasourceUid: loki

--- a/docker/local/tempo/tempo.yaml
+++ b/docker/local/tempo/tempo.yaml
@@ -6,8 +6,6 @@ distributor:
   receivers:
     otlp:
       protocols:
-        grpc:
-          endpoint: "0.0.0.0:4317"
         http:
           endpoint: "0.0.0.0:4318"
 

--- a/docker/local/tempo/tempo.yaml
+++ b/docker/local/tempo/tempo.yaml
@@ -1,0 +1,68 @@
+server:
+  http_listen_port: 3200
+
+# OTLP 수신
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+# Trace Storage
+storage:
+  trace:
+    backend: s3
+    s3:
+      endpoint: s3.ap-northeast-2.amazonaws.com
+      region: ap-northeast-2
+      bucket: onestep-bucket-a508
+      prefix: traces/local
+      access_key: ${S3_ACCESS_KEY}
+      secret_key: ${S3_SECRET_KEY}
+      forcepathstyle: true
+    wal:
+      path: /var/tempo/wal
+    pool:
+      max_workers: 10
+      queue_depth: 1000
+
+# Metric 생성
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: local
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+  processor:
+    # span-metrics
+    span_metrics:
+      dimensions:
+        - service.name
+        - http.method
+        - http.status_code
+        - http.route
+    # service-graphs
+    service_graphs:
+      dimensions:
+        - service.name
+    # local-blocks: TraceQL Metrics
+    local_blocks:
+      max_live_traces: 50000
+      flush_to_storage: true
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors:
+        - service-graphs
+        - span-metrics
+        - local-blocks

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -102,6 +102,13 @@ dependencies {
 
     // WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // Trace Micrometer
+    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
+
+    // Logstash Logback Encoder
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 }
 
 // QueryDSL Q-class generation

--- a/spring/src/main/java/com/a508/onestep/global/aop/ServiceLoggingAspect.java
+++ b/spring/src/main/java/com/a508/onestep/global/aop/ServiceLoggingAspect.java
@@ -1,0 +1,39 @@
+package com.a508.onestep.global.aop;
+
+import com.a508.onestep.global.logging.utils.LogUtils;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class ServiceLoggingAspect {
+
+    private final ObservationRegistry observationRegistry;
+
+    public ServiceLoggingAspect(ObservationRegistry observationRegistry) {
+        this.observationRegistry = observationRegistry;
+    }
+
+    @Around("within(@org.springframework.stereotype.Service *)")
+    public Object logServiceMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+        String method = joinPoint.getSignature().toShortString();
+        Observation observation = Observation.createNotStarted(method, observationRegistry).start();
+        long start = System.currentTimeMillis();
+        try {
+            Object result = joinPoint.proceed();
+            LogUtils.info("method={} duration={}ms status=OK", method, System.currentTimeMillis() - start);
+            return result;
+        } catch (Throwable e) {
+            LogUtils.error("method={} duration={}ms status=FAIL error={}",
+                    method, System.currentTimeMillis() - start, e.getMessage());
+            observation.error(e);
+            throw e;
+        } finally {
+            observation.stop();
+        }
+    }
+}

--- a/spring/src/main/java/com/a508/onestep/global/exception/GlobalExceptionHandler.java
+++ b/spring/src/main/java/com/a508/onestep/global/exception/GlobalExceptionHandler.java
@@ -16,14 +16,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e, HttpServletRequest request) {
-        LogUtils.error("Business Exception: {}", request);
-        LogUtils.exceptionWithCause(e);
+        LogUtils.error(e, request);
         return ErrorResponse.of(e.getBaseCode());
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException e, HttpServletRequest request) {
-        LogUtils.error("Resource Not Found", request);
         String path = request.getRequestURI();
 
         // Swagger 관련 경로는 Spring이 기본 처리하도록 예외를 다시 던짐
@@ -33,7 +31,7 @@ public class GlobalExceptionHandler {
             throw e;
         }
 
-        LogUtils.exceptionWithCause(e);
+        LogUtils.error(e, request);
         return ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND);
     }
 
@@ -51,8 +49,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
-        LogUtils.error("Unhandled exception", request);
-        LogUtils.exceptionWithCause(e);
+        LogUtils.error(e, request);
         return ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 

--- a/spring/src/main/java/com/a508/onestep/global/logging/filter/LoggingFilter.java
+++ b/spring/src/main/java/com/a508/onestep/global/logging/filter/LoggingFilter.java
@@ -1,6 +1,8 @@
 package com.a508.onestep.global.logging.filter;
 
 import com.a508.onestep.global.logging.utils.LogUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -15,15 +17,11 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Optional;
-import java.util.UUID;
 
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
-
-    public static final String HEADER_REQUEST_ID = "X-Request-ID";
-    public static final String MDC_REQUEST_ID = "requestID";
-
 
 
     @Override
@@ -34,31 +32,47 @@ public class LoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String requestId = Optional.ofNullable(request.getHeader(HEADER_REQUEST_ID))
-                .filter(s -> !s.isBlank())
-                .orElse(UUID.randomUUID().toString());
+        Long start = System.currentTimeMillis();
 
-        long start = System.currentTimeMillis();
-
-        // MDC
-        MDC.put(MDC_REQUEST_ID, requestId);
-        response.setHeader(HEADER_REQUEST_ID, requestId);
+        // BusinessContext
+        MDC.put("requestMethod", request.getMethod());
+        MDC.put("requestPath", request.getRequestURI());
+        MDC.put("clientIp", getClientIp(request));
+        MDC.put("userAgent", Optional.ofNullable(request.getHeader("User-Agent")).orElse("-"));
+        MDC.put("userId", extractUserId(request));
 
         ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
         ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
+        // log
         try {
-            // Log
-            logRequest(requestWrapper, requestId);
+            logRequest(requestWrapper);
             filterChain.doFilter(requestWrapper, responseWrapper);
-        } catch (Exception ex) {
-            // Error
-            LogUtils.error(ex, requestWrapper);
+        } catch (Exception e) {
+            MDC.put("errorType", e.getClass().getSimpleName());
+            MDC.put("errorMessage", e.getMessage());
+            LogUtils.error(e, requestWrapper);
+            throw e;
         } finally {
-            logResponse(responseWrapper, start, requestId);
-            // response 바디를 실제로 내보내기
+            Long tookMs = System.currentTimeMillis() - start;
+
+            // Json
+            MDC.put("responseStatus", String.valueOf(responseWrapper.getStatus()));
+            MDC.put("duration_ms", String.valueOf(tookMs));
+
+            logResponse(responseWrapper, tookMs);
             responseWrapper.copyBodyToResponse();
-            MDC.remove(MDC_REQUEST_ID);
+
+            // MDC 비우기
+            MDC.remove("requestMethod");
+            MDC.remove("requestPath");
+            MDC.remove("clientIp");
+            MDC.remove("userAgent");
+            MDC.remove("userId");
+            MDC.remove("responseStatus");
+            MDC.remove("duration_ms");
+            MDC.remove("errorType");
+            MDC.remove("errorMessage");
         }
 
     }
@@ -75,38 +89,73 @@ public class LoggingFilter extends OncePerRequestFilter {
         /*
      Request 기록
      */
-    private void logRequest(HttpServletRequest request, String requestId) {
+    private void logRequest(HttpServletRequest request) {
         String method = request.getMethod();
         String uri = request.getRequestURI();
         String query = request.getQueryString();
 
         LogUtils.info(
-                "[REQ] id={} {} {}{}",
-                requestId, method, uri, (query != null ? query : "")
+                "[REQ] {} {}{}", method, uri, (query != null ? query : "")
         );
     }
 
     /*
     Response 콘솔 로그
      */
-    private void logResponse(ContentCachingResponseWrapper responseWrapper, long start, String requestId) throws IOException {
+    private void logResponse(ContentCachingResponseWrapper responseWrapper, long tookMs) {
 
-        long tookMs = System.currentTimeMillis() - start;
-        int status = responseWrapper.getStatus(); // HTTP STATUS
+        LogUtils.info("[RES] status={} took={}ms", responseWrapper.getStatus(), tookMs);
 
         byte[] body = responseWrapper.getContentAsByteArray();
-        StringBuilder bodyStringBuilder = new StringBuilder();
-        String bodyString = "";
-        if ( body != null && body.length > 0) {
-            bodyString = bodyStringBuilder.append(new String(body, StandardCharsets.UTF_8)).toString();
-            if (bodyString.length() > 2000) {
-                bodyString = bodyString.substring(0, 2000) + "...(omission)";
+        if (logger.isDebugEnabled()) {
+            if (body.length > 0) {
+                String bodyString = new String(body, StandardCharsets.UTF_8);
+                if (bodyString.length() > 2000) {
+                    bodyString = bodyString.substring(0, 2000) + "...(omission)";
+                }
+                LogUtils.debug("[RES-BODY] {}", bodyString);
             }
         }
-        LogUtils.info("[RES] id={} status={} took={}", requestId, status, tookMs);
-        LogUtils.debug("[RES-BODY] {}", bodyString);
+    }
 
-        // response 바디를 실제로 내보내기
-        responseWrapper.copyBodyToResponse();
+
+    /*
+    JWT에서 userId 추출
+     */
+    private String extractUserId(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            try {
+                String[] parts = authHeader.substring(7).split("\\.");
+                String userCode = "";
+
+                if (parts.length == 3) {
+                    String payload = new String(Base64.getUrlDecoder().decode(parts[1]));
+                    // payload
+                    try {
+                        ObjectMapper mapper = new ObjectMapper();
+                        JsonNode node = mapper.readTree(payload);
+                        userCode = node.has("sub") ? node.get("sub").asText() : "anonymous";
+                    } catch (Exception e) {
+                        return "anonymous";
+                    }
+                    return userCode;
+                }
+            } catch (Exception e) {
+                return "anonymous";
+            }
+        }
+        return "anonymous";
+    }
+
+    /*
+    Client의 IP를 추출
+     */
+    private String getClientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            return xff.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/spring/src/main/java/com/a508/onestep/global/logging/utils/LogUtils.java
+++ b/spring/src/main/java/com/a508/onestep/global/logging/utils/LogUtils.java
@@ -4,8 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 @Component
 @Slf4j
@@ -16,22 +14,6 @@ public class LogUtils {
      */
     public static String exception(Throwable e) {
         return e == null ? "" : e.getMessage();
-    }
-
-    public static String exceptionWithCause(Throwable e) {
-        if (e == null) return "";
-
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        e.printStackTrace(pw);
-
-        Throwable cause = e.getCause();
-        while (cause != null) {
-            pw.println("Caused by:");
-            cause.printStackTrace(pw);
-            cause = cause.getCause();
-        }
-        return sw.toString();
     }
 
     /*
@@ -72,6 +54,6 @@ public class LogUtils {
             return;
         }
         log.error(">>> Request URI : [{}] {}", request.getMethod(), request.getRequestURI());
-        log.error(">>> Exception : {}", exceptionWithCause(e), e);
+        log.error(">>> Exception : {}", exception(e), e);
     }
 }

--- a/spring/src/main/resources/application-dev.yaml
+++ b/spring/src/main/resources/application-dev.yaml
@@ -71,6 +71,12 @@ management:
   metrics:
     tags:
       application: onestep-api
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://tempo:4318/v1/traces
 
 openapi:
   base-url: http://${SERVER_IP}:8080

--- a/spring/src/main/resources/application-local.yaml
+++ b/spring/src/main/resources/application-local.yaml
@@ -65,3 +65,9 @@ management:
   metrics:
     tags:
       application: onestep-api
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318/v1/traces

--- a/spring/src/main/resources/logback-spring.xml
+++ b/spring/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<configuration>
+
+    <!-- Plain text -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [traceId=%X{traceId} spanId=%X{spanId}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- JSON -->
+    <!-- Promtail → Loki -->
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+            <includeMdcKeyName>requestPath</includeMdcKeyName>
+        </encoder>
+    </appender>
+
+    <!-- local 제외 -->
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <root level="INFO">
+            <appender-ref ref="JSON"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## relavant issue number
- #27 

## 어떤 이유로 MR를 하셨나요?
- [x] feature 병합(feature issue #를 남겨주세요)
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용

- **`LogUtils` 수정**
```java
    // Request ERROR LOG
    public static void error(Throwable e, HttpServletRequest request) {
        if (request == null) {
            log.error(">>> Exception : {}", exception(e), e);
            return;
        }
        log.error(">>> Request URI : [{}] {}", request.getMethod(), request.getRequestURI());
        log.error(">>> Exception : {}", exception(e), e);
    }
```
- 기존에는 trace 단위 추적이 누락되어서 수정 됐습니다(기존이 단순 메시지만 출력되고 실제 StackTrace가 생략되던 부분을 개선했습니다)
- `exception(e)` 메시지 출력과 함께 `Throwable` 자체를 함께 전달하여 스택 트레이스 전체가 로그에 기록되도록 변경했습니다(원래 요약되어 출력)


<br>

- **`GlobalExceptionHandler` 수정**
```java
@ExceptionHandler(BusinessException.class)
public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e, HttpServletRequest request) {
    LogUtils.error(e, request);
    return ErrorResponse.of(e.getBaseCode());
}
```
- `LogUtils.error(e, request);` 로 트레이스 출력하도록 수정

<br>

- **Trace 추적을 위한 의존성 추가**
```groovy
implementation 'io.micrometer:micrometer-tracing-bridge-otel'
implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
```
- Micrometer 기반 트레이싱을 OpenTelemetry로 브릿지함
- OTLP 프로토콜을 통해 Trace와 Span 데이터를 외부수집 시스템인 Tempo로 전송하도록 설정했습니다
- Trace 및 Span 단위의 관측으로 MDC에 등록

<br>

- **Tempo 오픈소스 추가**
```yaml
  tempo:
    image: grafana/tempo:2.6.1
    container_name: tempo
    env_file:
      - .env
    command: [ "-config.file=/etc/tempo/tempo.yml", "-config.expand-env=true" ]
    volumes:
      - ./tempo/tempo.yaml:/etc/tempo/tempo.yml:ro
      - tempo-data:/var/tempo
    ports:
      - "3200:3200"
      - "4318:4318"
    networks:
      - monitoring
```
- Tempo 컨테이너를 추가
- OLTP HTTP 수신 포트 4318 추가
- Tempo API 포트 3200 추가
- 애플리케이션에서의 트레이스 로그들을 수집하고 s3를 Storage Object로 지정해 저장

<br>

- **`tempo-config.yaml`**
- OTLP Receiver 설정
```yaml
# OTLP 수신
distributor:
  receivers:
    otlp:
      protocols:
        http:
          endpoint: "0.0.0.0:4318"
```
- OTLP http 수신 포트 추가

<br>

- Storage 설정
```yaml
# Trace Storage
storage:
  trace:
    backend: s3
    s3:
      endpoint: s3.ap-northeast-2.amazonaws.com
      region: ap-northeast-2
      bucket: onestep-bucket-a508
      prefix: traces/dev
      access_key: ${S3_ACCESS_KEY}
      secret_key: ${S3_SECRET_KEY}
      forcepathstyle: true
    wal:
      path: /var/tempo/wal
    pool:
      max_workers: 100
      queue_depth: 10000
```
- S3 Object Storage에 트레이스를 저장
- WAL 저장으로 백업 설정

<br>

- Metric Generator 활성
```yaml
processors:
  - service-graphs
  - span-metrics
```
- `span-metrics`와 `service-graphs`
- 서비스 간 호출 관계를 생성, Span 메트릭 자동 생성
- 프로메테우스 연동

<br>

- **`datasource.yaml`**
- 설정된 Datasource는 Prometheus(메트릭) , Loki(로그), Tempo(트레이스) 지정했습니다

<br>

```yaml
tracesToLogsV2:
  datasourceUid: loki
```
- Trace -> 관련 로그를 자동 연결

```yaml
serviceMap:
  datasourceUid: prometheus
```
- 서비스 맵을 시각화

```yaml
nodeGraph:
  enabled: true
```
- 노드 그래프 활성화

<br>

- 현재의 구조가 다음과 같다고 할 수 있음
```
Prometheus (메트릭) ←──── serviceMap ────→ Tempo (트레이스)
                                              │
                              tracesToLogsV2   │  lokiSearch
                                              ↓
                                         Loki (로그)
```

<br>


- pmm에 대해 열어두는 것은 선택사항이라고 판단하여 docker-compose 파일 분리